### PR TITLE
Ensure logged-in user extraction honors explicit User line

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,6 +399,21 @@
     }
 
     function extractLoggedInUser(lines) {
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line) continue;
+        if (line.trim() === 'User:') {
+          for (let j = i + 1; j < lines.length; j++) {
+            const nextLine = lines[j];
+            if (!nextLine) continue;
+            const cleaned = cleanValue(nextLine);
+            if (cleaned) {
+              return cleaned;
+            }
+          }
+          break;
+        }
+      }
       const user = findLineValue(lines, 'User');
       if (user) return user;
       const processOwner = findLineValue(lines, 'Process Owner');


### PR DESCRIPTION
## Summary
- ensure logged-in user extraction first captures values that follow an explicit `User:` line
- retain existing fallbacks when no dedicated user line is present

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d73a58a10883299f305f2097e7f093