### PR TITLE
Adjust classification extraction from CLASSIFICATION section

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,6 +383,27 @@
     }
 
     function extractClassification(lines, tableData) {
+      const classificationHeaderIndex = lines.findIndex((line) =>
+        line && line.trim() === 'CLASSIFICATION'
+      );
+      if (classificationHeaderIndex !== -1) {
+        let linesBelow = 0;
+        for (
+          let i = classificationHeaderIndex + 1;
+          i < lines.length;
+          i++
+        ) {
+          linesBelow += 1;
+          if (linesBelow === 7) {
+            const targetLine = lines[i];
+            const cleaned = cleanValue(targetLine);
+            if (cleaned) {
+              return cleaned;
+            }
+            break;
+          }
+        }
+      }
       if (tableData.CLASSIFICATION) {
         return cleanValue(tableData.CLASSIFICATION);
       }


### PR DESCRIPTION
## Summary
- add logic to read the classification value from the seventh line after the CLASSIFICATION header before falling back to existing fallbacks

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d749ffd02083298e06fc55c10fd8e5