### PR TITLE
Handle Command Line formatting edge case

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,7 +475,38 @@
       const classification = extractClassification(lines, tableData);
       const virusTotal = extractVirusTotalLink(chunk);
       const target = findLineValue(lines, 'Target') || 'N/A';
-      const commandLine = findLineValue(lines, 'Command Line') || 'N/A';
+      let commandLine = findLineValue(lines, 'Command Line') || '';
+      const exactCommandLineIndex = (() => {
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i];
+          if (!line) continue;
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          if (trimmed.toLowerCase() === 'command line:') {
+            return i;
+          }
+        }
+        return -1;
+      })();
+      if (exactCommandLineIndex !== -1) {
+        let candidate = '';
+        for (let i = exactCommandLineIndex + 1; i < lines.length; i++) {
+          const nextLine = lines[i];
+          if (!nextLine) continue;
+          const cleaned = cleanValue(nextLine);
+          if (!cleaned) continue;
+          candidate = cleaned;
+          break;
+        }
+        if (!candidate || candidate.endsWith(':')) {
+          commandLine = 'N/A';
+        } else {
+          commandLine = candidate;
+        }
+      }
+      if (!commandLine) {
+        commandLine = 'N/A';
+      }
       const additionalInfo = extractAdditionalInfo(lines, tableData);
 
       const summaryLines = [


### PR DESCRIPTION
## Summary
- update command line parsing to read the value from the line following an exact "Command Line:" entry
- fall back to N/A when the next line is another label ending in a colon

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d74c85f6648329b2aa9af0774dd011