### PR TITLE
Update additional info extraction for FortiEDR formatter

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,6 +325,20 @@
     }
 
     function extractAdditionalInfo(lines, tableData) {
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line) continue;
+        if (line.trim() === 'Raw Data Items: All') {
+          const targetIndex = i + 13;
+          if (targetIndex < lines.length) {
+            const candidate = cleanValue(lines[targetIndex]);
+            if (candidate) {
+              return candidate;
+            }
+          }
+          break;
+        }
+      }
       if (tableData.DESTINATION) {
         return cleanValue(tableData.DESTINATION);
       }


### PR DESCRIPTION
## Summary
- extract the additional information value from the 13th line following the "Raw Data Items: All" marker
- retain the existing table-based and keyword fallbacks when the expected line is missing or empty

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7721d32448329840ce6baa46b01c7