### PR TITLE
Handle tech notes without when-created-by section

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,10 +485,6 @@
       const hasWhenCreatedBy = lines.some(line =>
         line && line.toLowerCase().includes('when created by:')
       );
-      if (!hasWhenCreatedBy) {
-        return '';
-      }
-
       const findSectionValues = (label, count) => {
         const index = lines.findIndex(line => line && line.trim() === label);
         if (index === -1) return [];
@@ -517,11 +513,13 @@
         parts.push('on');
       }
 
-      const createdByText = whenCreatedByValues.join(' ');
-      if (createdByText) {
-        parts.push(`when created by: ${createdByText}`);
-      } else {
-        parts.push('when created by:');
+      if (hasWhenCreatedBy) {
+        const createdByText = whenCreatedByValues.join(' ');
+        if (createdByText) {
+          parts.push(`when created by: ${createdByText}`);
+        } else {
+          parts.push('when created by:');
+        }
       }
 
       return parts.join(' ').replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
## Summary
- keep generating tech notes content when the "When created by" section is missing
- only append the "when created by" phrase when the corresponding lines exist

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d84f2148988329a6d99d4c813e5b9b